### PR TITLE
Add CUDA kernels for ray tracing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,12 +9,14 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Images = "916415d5-f1e6-5110-898d-aaa5f9f070e0"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
+CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 
 [compat]
 julia = "1.8"
 Images = "0.25"
 StaticArrays = "1.0"
 FileIO = "1.0"
+CUDA = "5"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
## Summary
- implement CUDA kernels for ray generation, shading, tone mapping and image averaging
- extend GPU render path to launch CUDA kernels when a CUDA device is detected
- add CUDA.jl as a project dependency

## Testing
- `JULIA_PKG_PRECOMPILE_AUTO=0 julia --project=. -e 'using Pkg; Pkg.resolve(); Pkg.instantiate()'`
- `JULIA_PKG_PRECOMPILE_AUTO=0 julia --project=. -e 'using SPIRA; scene = SPIRA.create_scene(); cam = SPIRA.Camera(SPIRA.Point3(0f0,1f0,3f0), SPIRA.Point3(0f0,0f0,0f0), SPIRA.Point3(0f0,1f0,0f0), 40f0, 1f0); img = SPIRA.render(scene, cam, 32, 18, samples_per_pixel=1, max_depth=1, output_path="test.png"); println(size(img))'` *(failed: precompilation interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68b92411ef748324ae83832a3a222709